### PR TITLE
Added support for PIN retrieval from FIDO2_PIN environment variable

### DIFF
--- a/tools/fido2-token.c
+++ b/tools/fido2-token.c
@@ -53,6 +53,7 @@ main(int argc, char **argv)
 	int ch;
 	int flags = 0;
 	char *device;
+	char *env_pin = 0;
 
 
 	// Parse command line arguments
@@ -64,6 +65,10 @@ main(int argc, char **argv)
 		}
 	}
 
+	// Support retrieving PIN from "FIDO2_PIN" environment variable
+	if (!global_pin && (env_pin = getenv("FIDO2_PIN"))) {
+		global_pin = strdup(env_pin);
+	}
 
 	while ((ch = getopt(argc, argv, TOKEN_OPT)) != -1) {
 		switch (ch) {


### PR DESCRIPTION
This change allows the user to set the PIN via the FIDO2_PIN environment variable. I found this useful when scripting around fido2-token2 on macOS, and wanted to avoid exposing the PIN on the command line.