### PR TITLE
Modification on the Arch Linux installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ To allow coexistence with the original tool, our version will be compiled and in
 ```bash
 git clone https://github.com/Token2/fido2-manage.git
 
+sudo pacman -S libfido2 cmake libcbor tk
+
 cd fido2-manage
 
 rm -rf build && mkdir build && cd build && cmake -USE_PCSC=ON ..
@@ -116,10 +118,6 @@ sudo make -C build install
 sudo ldconfig
 
 chmod 755 fido2-manage.sh
-
-sudo apt install -y python3-tk
-
-sudo pacman -S tk
 
 python3 gui.py
 


### PR DESCRIPTION
Hello,

I'm making this pull request to modify some information on the Arch Linux installation guide. I encountered some issues when making and running the app, where packages were missed. So for the next one who want to install the Fido2 Manage on Arch Linux, It might be interesting to integrate it by default in the installation process.

What I have done :  

* Deleted a command to install a package on a Debian based distro (not applicable on Arch Linux).
* Added packages required to build and run properly the app which are not installed by default in this distro (libfido2, cmake, libcbor).
* Unified pacman command to install package in the same line before the build.

If you need further information, feel free to reach me :)