### PR TITLE
Simplify and fix device name extraction

### DIFF
--- a/fido2-manage.sh
+++ b/fido2-manage.sh
@@ -123,7 +123,7 @@ if $list; then
     echo "$command_output" | while read -r line; do
         if [[ $line =~ ^([^:]+) ]]; then
         
-         echo "Device [$device_count] : $(echo "${line}" | grep -oP '\(([^)]+)\)' | sed 's/(\(.*\))/\1/')"
+         echo "Device [$device_count] : $(echo "${line}" | grep -oP '(?<=\()(.+)(?=\))')"
 
             device_count=$((device_count + 1))
         fi


### PR DESCRIPTION
* Correclty handles when the device name ends with `)`
* Drops superfluous `sed`

Before:

```
./fido2-manage.sh -list
Device [1] : TOKEN2 FIDO2 Security Key(0016
```

After:

```
./fido2-manage.sh -list
Device [1] : TOKEN2 FIDO2 Security Key(0016)
```