### PR TITLE
Add Fedora (43) installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,5 +126,32 @@ python3 gui.py
 
 ```
 
+### Fedora ###
+
+The below installation instructions were written for Fedora 43, but might also work on other versions
+of the operating system.
+
+```sh
+git clone https://github.com/Token2/fido2-manage.git
+
+cd fido2-manage
+
+sudo dnf install -y zlib-devel pkg-config cmake libcbor-devel pcsc-lite-devel openssl-devel systemd-devel
+
+rm -rf build && mkdir build && cd build && cmake -USE_PCSC=ON ..
+
+cd ..
+
+make -C build
+
+sudo make -C build install
+
+sudo ldconfig
+
+chmod 755 fido2-manage.sh
+
+python3 gui.py
+```
+
 ### macOS ###
 [Refer to this file for macOS instructions](README.MACOS.md)


### PR DESCRIPTION
I am using Fedora 43 Workstation and could not find an easy copy-paste way of installing `fido2-manage` for this OS. Luckily, adapting the existing instructions for Fedora was pretty easy, with the help of `packages.fedoraproject.org` and a little bit of common sense. Copying, pasting and executing my own set of instructions yielded a successful result.

<img width="1164" height="1072" alt="screenshot showing a terminal window with logs from the make program, with a Fido2.1 manager GUI window in front" src="https://github.com/user-attachments/assets/96e68991-39e6-495a-be04-f7cbec6612e5" />
