### PR TITLE
Add ghostty to gui.py as term candidate

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -17,6 +17,7 @@ def detect_terminal():
         ("lxterminal", ["-e"]),
         ("tilix", ["-e"]),
         ("mate-terminal", ["-e"]),
+        ("ghostty", ["-e"]),
     ]
     for term, flag in candidates:
         if shutil.which(term):


### PR DESCRIPTION
Launching the gui from ghostty failed with ` No supported terminal emulator found. Please install xterm or gnome-terminal.` initially, but after adding it to the list of candidates it worked without issues.  
Since only the detection fails, but the UI itself works (I could see my key, add a pin, list passkeys etc) I propose adding ghostty to the candidates.  
If theres anything I should test with the GUI first please let me know.