### PR TITLE
Add GNU-style long-form aliases for all CLI flags

### DIFF
--- a/fido2-manage-mac.sh
+++ b/fido2-manage-mac.sh
@@ -77,24 +77,24 @@ show_message() {
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
-        -list) list=true ;;
-        -info) info=true ;;
-        -device) device="$2"; shift ;;
-        -pin) pin="$2"; shift ;;
-        -storage) storage=true ;;
-        -fingerprint) fingerprint=true ;;        
-        -residentKeys) residentKeys=true ;;
-        -domain) domain="$2"; shift ;;
-        -delete) delete=true ;;
-        -credential) credential="$2"; shift ;;
-        -changePIN) changePIN=true ;;
-        -setPIN) setPIN=true ;;
-        -reset) reset=true ;;
-        -uvs) uvs=true ;;
-        -uvd) uvd=true ;;
-        -forcePINchange) forcePINchange=true ;;
-        -setMinimumPIN) setMinimumPIN="$2"; shift ;;
-        -help) help=true ;;
+        -list|--list) list=true ;;
+        -info|--info) info=true ;;
+        -device|--device) device="$2"; shift ;;
+        -pin|--pin) pin="$2"; shift ;;
+        -storage|--storage) storage=true ;;
+        -fingerprint|--fingerprint) fingerprint=true ;;
+        -residentKeys|--residentKeys) residentKeys=true ;;
+        -domain|--domain) domain="$2"; shift ;;
+        -delete|--delete) delete=true ;;
+        -credential|--credential) credential="$2"; shift ;;
+        -changePIN|--changePIN) changePIN=true ;;
+        -setPIN|--setPIN) setPIN=true ;;
+        -reset|--reset) reset=true ;;
+        -uvs|--uvs) uvs=true ;;
+        -uvd|--uvd) uvd=true ;;
+        -forcePINchange|--forcePINchange) forcePINchange=true ;;
+        -setMinimumPIN|--setMinimumPIN) setMinimumPIN="$2"; shift ;;
+        -help|--help) help=true ;;
         *) show_message "Unknown parameter: $1" "Error"; exit 1 ;;
     esac
     shift

--- a/fido2-manage.sh
+++ b/fido2-manage.sh
@@ -28,23 +28,23 @@ show_message() {
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
-        -list) list=true ;;
-        -info) info=true ;;
-        -device) device="$2"; shift ;;
-        -pin) pin="$2"; shift ;;
-        -storage) storage=true ;;
-        -fingerprint) fingerprint=true ;;
-        -residentKeys) residentKeys=true ;;
-        -domain) domain="$2"; shift ;;
-        -delete) delete=true ;;
-        -credential) credential="$2"; shift ;;
-        -changePIN) changePIN=true ;;
-        -setPIN) setPIN=true ;;
-        -reset) reset=true ;;
-        -setMinimumPIN) setMinimumPIN="$2"; shift ;;
-        -uvs) uvs=true ;;
-        -uvd) uvd=true ;;
-        -help) help=true ;;
+        -list|--list) list=true ;;
+        -info|--info) info=true ;;
+        -device|--device) device="$2"; shift ;;
+        -pin|--pin) pin="$2"; shift ;;
+        -storage|--storage) storage=true ;;
+        -fingerprint|--fingerprint) fingerprint=true ;;
+        -residentKeys|--residentKeys) residentKeys=true ;;
+        -domain|--domain) domain="$2"; shift ;;
+        -delete|--delete) delete=true ;;
+        -credential|--credential) credential="$2"; shift ;;
+        -changePIN|--changePIN) changePIN=true ;;
+        -setPIN|--setPIN) setPIN=true ;;
+        -reset|--reset) reset=true ;;
+        -setMinimumPIN|--setMinimumPIN) setMinimumPIN="$2"; shift ;;
+        -uvs|--uvs) uvs=true ;;
+        -uvd|--uvd) uvd=true ;;
+        -help|--help) help=true ;;
         *) show_message "Unknown parameter: $1" "Error"; exit 1 ;;
     esac
     shift


### PR DESCRIPTION
All flags in fido2-manage.sh and fido2-manage-mac.sh now accept both single-dash (-flag) and double-dash (--flag) forms, e.g. --device, --list, --help. Single-dash forms continue to work unchanged.
Closes the TODO item: "add Linux-style aliases for arguments (i.e. `--device` in addition to `-device`)"

All flags in `fido2-manage.sh` and `fido2-manage-mac.sh` now accept both single-dash and GNU-style double-dash forms. The original single-dash forms continue to work unchanged — this is purely additive.

**Changes:**
- `fido2-manage.sh` — 17 flags updated
- `fido2-manage-mac.sh` — 18 flags updated (includes `--forcePINchange`)

**Example:**
```bash
# Both forms now work identically
./fido2-manage.sh -list
./fido2-manage.sh --list

./fido2-manage.sh -device 1 -info
./fido2-manage.sh --device 1 --info
No changes to the compiled binary (fido2-token2) or GUI code.


