### PR TITLE
Fix hardcoded FIDO2_TOKEN_CMD path in fido2-manage.sh

### DIFF
--- a/fido2-manage.sh
+++ b/fido2-manage.sh
@@ -1,6 +1,24 @@
 #!/bin/bash
 
-FIDO2_TOKEN_CMD="/usr/local/bin/fido2-token2"
+# Locate fido2-token2: check next to this script first (dev builds),
+# then fall back to PATH (handles any install prefix).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+FIDO2_TOKEN_CMD=""
+for candidate in \
+    "$SCRIPT_DIR/fido2-token2" \
+    "$SCRIPT_DIR/build/tools/fido2-token2" \
+    "$SCRIPT_DIR/tools/fido2-token2"
+do
+    if [[ -f "$candidate" ]]; then
+        FIDO2_TOKEN_CMD="$candidate"
+        break
+    fi
+done
+
+if [[ -z "$FIDO2_TOKEN_CMD" ]]; then
+    FIDO2_TOKEN_CMD="$(command -v fido2-token2 2>/dev/null)"
+fi
 
 list=false
 info=false
@@ -107,6 +125,11 @@ fi
 
 if ! $list && ! $info && [[ -z $device ]] && ! $fingerprint && ! $storage && ! $residentKeys && [[ -z $domain ]] && ! $delete && [[ -z $credential ]] && ! $changePIN && ! $setMinimumPIN && ! $setPIN && ! $reset && ! $uvs && ! $uvd && ! $help; then
     show_help
+    exit 1
+fi
+
+if [[ -z "$FIDO2_TOKEN_CMD" ]]; then
+    show_message "fido2-token2 not found. Install it or ensure it is on your PATH." "Error"
     exit 1
 fi
 


### PR DESCRIPTION
Replaces the hardcoded /usr/local/bin/fido2-token2 with dynamic detection: checks alongside the script first (dev builds), then falls back to PATH so any install prefix works correctly.

Fixes #32

`fido2-manage.sh` had `FIDO2_TOKEN_CMD` hardcoded to `/usr/local/bin/fido2-token2`,which breaks when installing to any other prefix (e.g. `/usr` via`-DCMAKE_INSTALL_PREFIX=/usr`).

**Fix:** Replace the hardcoded path with dynamic detection:
1. Check alongside the script itself (covers dev builds and local installs)
2. Check `build/tools/` and `tools/` relative paths
3. Fall back to `command -v fido2-token2` — respects `$PATH` and works   with any install prefix automatically

A clear error message is shown if the binary cannot be found by any method.
Note: `fido2-manage-mac.sh` already had equivalent path detection logic and is unaffected.
